### PR TITLE
fix ssm backend get prefix error

### DIFF
--- a/backends/ssm/client.go
+++ b/backends/ssm/client.go
@@ -72,7 +72,7 @@ func (c *Client) getParametersWithPrefix(prefix string) (map[string]string, erro
 		Recursive:      aws.Bool(true),
 		WithDecryption: aws.Bool(true),
 	}
-	c.client.GetParametersByPathPages(params,
+	err = c.client.GetParametersByPathPages(params,
 		func(page *ssm.GetParametersByPathOutput, lastPage bool) bool {
 			for _, p := range page.Parameters {
 				parameters[*p.Name] = *p.Value


### PR DESCRIPTION
We should capture and bubble error message from AWS GetParametersByPathPages

Reference: https://docs.aws.amazon.com/sdk-for-go/api/service/ssm/#SSM.GetParametersByPathPages
